### PR TITLE
Fix LogoAnimationView module import issue

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import LogoAnimationView
 
 struct ContentView: View {
     @EnvironmentObject var gameManager: GameManager

--- a/LogoAnimationView.swift
+++ b/LogoAnimationView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
-struct LogoAnimationView: View {
+public struct LogoAnimationView: View {
     @State private var isAnimating = false
 
-    var body: some View {
+    public var body: some View {
         Image("logo")
             .resizable()
             .scaledToFit()

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .target(
             name: "coffemonkey",
             dependencies: [
-                .product(name: "FirebaseFirestore", package: "firebase-ios-sdk")
+                .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
+                "LogoAnimationView"
             ]),
         .testTarget(
             name: "coffemonkeyTests",


### PR DESCRIPTION
Update `Package.swift`, `ContentView.swift`, and `LogoAnimationView.swift` to resolve the module import issue.

* **Package.swift**
  - Add `LogoAnimationView` to the `coffemonkey` target dependencies.

* **ContentView.swift**
  - Remove the import statement for `LogoAnimationView`.

* **LogoAnimationView.swift**
  - Make `LogoAnimationView` struct public and its body public.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abbayram/coffemonkey/pull/5?shareId=7742419f-f4de-49ca-9003-89b7dd6f4039).