### PR TITLE
Fix import errors for GoogleSignIn and PackageDescription

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,13 +11,15 @@ let package = Package(
             targets: ["coffemonkey"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "8.0.0")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "8.0.0"),
+        .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "6.0.0")
     ],
     targets: [
         .target(
             name: "coffemonkey",
             dependencies: [
                 .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
+                .product(name: "GoogleSignIn", package: "GoogleSignIn-iOS"),
                 "LogoAnimationView"
             ]),
         .testTarget(


### PR DESCRIPTION
Add GoogleSignIn dependency and import statement.

* Modify `Package.swift` to include `GoogleSignIn` dependency in the `dependencies` array.
* Add `GoogleSignIn` product to the `dependencies` array of the `coffemonkey` target.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abbayram/coffemonkey/pull/8?shareId=faff0145-1556-423e-aab2-ed12b3bd00e0).