### PR TITLE
Fix User type not found in scope

### DIFF
--- a/AppleSignInCoordinator.swift
+++ b/AppleSignInCoordinator.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import FirebaseAuth
 
 class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     

--- a/FirebaseManager.swift
+++ b/FirebaseManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Firebase
+import FirebaseAuth
 
 class FirebaseManager {
     static let shared = FirebaseManager()


### PR DESCRIPTION
Add FirebaseAuth import to resolve missing User type

* Add `import FirebaseAuth` at the top of `FirebaseManager.swift`
* Add `import FirebaseAuth` at the top of `AppleSignInCoordinator.swift`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abbayram/coffemonkey/pull/10?shareId=9e7c2926-5382-45b2-b20c-4f461a6d9164).