### PR TITLE
Add connectPlayer method to FirebaseManager

### DIFF
--- a/FirebaseManager.swift
+++ b/FirebaseManager.swift
@@ -60,4 +60,20 @@ class FirebaseManager {
             }
         }
     }
+
+    func connectPlayer(player: Player, completion: @escaping (Bool) -> Void) {
+        let playerData: [String: Any] = [
+            "name": player.name,
+            "health": player.health
+        ]
+
+        db.collection("players").document(player.id.uuidString).setData(playerData) { error in
+            if let error = error {
+                print("Error connecting player: \(error)")
+                completion(false)
+            } else {
+                completion(true)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add `connectPlayer` method to `FirebaseManager` to register a player in Firestore.

* Define `connectPlayer` method in `FirebaseManager` that takes a `Player` object and a completion handler.
* Create a dictionary with player data including name and health.
* Use `setData` method to store player data in Firestore.
* Call completion handler with success flag after storing player data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abbayram/coffemonkey/pull/14?shareId=f381947b-892f-456d-820e-a78b1570f65f).