### PR TITLE
Update navigation to options page

### DIFF
--- a/OptionsPageView.swift
+++ b/OptionsPageView.swift
@@ -29,7 +29,8 @@ struct OptionsPageView: View {
             Spacer()
 
             Button(action: {
-                // Action for playing online with random people
+                // Navigate to ContentView for playing online with random people
+                navigateToContentView()
             }) {
                 Text("Play Online with Random People")
                     .font(.title)
@@ -41,7 +42,8 @@ struct OptionsPageView: View {
             .padding()
 
             Button(action: {
-                // Action for playing with friends
+                // Navigate to ContentView for playing with friends
+                navigateToContentView()
             }) {
                 Text("Play Friends")
                     .font(.title)
@@ -54,6 +56,12 @@ struct OptionsPageView: View {
 
             Spacer()
         }
+    }
+
+    private func navigateToContentView() {
+        // Implement navigation to ContentView
+        // This is a placeholder for the actual navigation logic
+        print("Navigating to ContentView")
     }
 }
 

--- a/StartPageView.swift
+++ b/StartPageView.swift
@@ -40,77 +40,54 @@ struct StartPageView: View {
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .padding()
 
-            Button(action: {
-                connectPlayer()
-            }) {
-                Text("Next")
-                    .font(.title)
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
-            }
-            .padding()
-            .disabled(isConnected)
-
-            if isConnected {
-                Button(action: {
-                    startGame()
-                }) {
-                    Text("Start Game")
-                        .font(.title)
-                        .padding()
-                        .background(Color.green)
-                        .foregroundColor(.white)
-                        .cornerRadius(10)
-                }
-                .padding()
-            }
-
-            // Apple ID Sign-In Button
-            SignInWithAppleButton(
-                .signIn,
-                onRequest: { request in
-                    request.requestedScopes = [.fullName, .email]
-                },
-                onCompletion: { result in
-                    switch result {
-                    case .success(let authorization):
-                        handleAppleSignIn(authorization: authorization)
-                    case .failure(let error):
-                        alertMessage = "Apple Sign-In failed: \(error.localizedDescription)"
-                        showAlert = true
+            NavigationView {
+                VStack {
+                    Button(action: {
+                        connectPlayer()
+                    }) {
+                        Text("Next")
+                            .font(.title)
+                            .padding()
+                            .background(Color.blue)
+                            .foregroundColor(.white)
+                            .cornerRadius(10)
                     }
+                    .padding()
+                    .disabled(isConnected)
+
+                    if isConnected {
+                        NavigationLink(destination: OptionsPageView()) {
+                            Text("Go to Options")
+                                .font(.title)
+                                .padding()
+                                .background(Color.green)
+                                .foregroundColor(.white)
+                                .cornerRadius(10)
+                        }
+                        .padding()
+                    }
+
+                    // Apple ID Sign-In Button
+                    SignInWithAppleButton(
+                        .signIn,
+                        onRequest: { request in
+                            request.requestedScopes = [.fullName, .email]
+                        },
+                        onCompletion: { result in
+                            switch result {
+                            case .success(let authorization):
+                                handleAppleSignIn(authorization: authorization)
+                            case .failure(let error):
+                                alertMessage = "Apple Sign-In failed: \(error.localizedDescription)"
+                                showAlert = true
+                            }
+                        }
+                    )
+                    .signInWithAppleButtonStyle(.black)
+                    .frame(width: 280, height: 45)
+                    .padding()
                 }
-            )
-            .signInWithAppleButtonStyle(.black)
-            .frame(width: 280, height: 45)
-            .padding()
-
-            // New buttons for playing online with random people and playing with friends
-            Button(action: {
-                // Action for playing online with random people
-            }) {
-                Text("Play Online with Random People")
-                    .font(.title)
-                    .padding()
-                    .background(Color.orange)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
             }
-            .padding()
-
-            Button(action: {
-                // Action for playing with friends
-            }) {
-                Text("Play Friends")
-                    .font(.title)
-                    .padding()
-                    .background(Color.purple)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
-            }
-            .padding()
         }
         .alert(isPresented: $showAlert) {
             Alert(title: Text("Error"), message: Text(alertMessage), dismissButton: .default(Text("OK")))

--- a/WordWarsApp.swift
+++ b/WordWarsApp.swift
@@ -16,7 +16,7 @@ struct WordWarsApp: App {
                 ContentView()
                     .environmentObject(gameManager)
             } else {
-                StartPageView()
+                OptionsPageView()
                     .onAppear {
                         NotificationCenter.default.addObserver(forName: NSNotification.Name("GameStarted"), object: nil, queue: .main) { _ in
                             isGameStarted = true


### PR DESCRIPTION
Update the navigation flow to display options for playing with friends or random people after clicking 'Next'.

* **StartPageView.swift**
  - Remove buttons for playing online with random people and playing with friends.
  - Add navigation to `OptionsPageView` after connecting the player.
  - Wrap the 'Next' button in a `NavigationView` and add a `NavigationLink` to `OptionsPageView`.

* **OptionsPageView.swift**
  - Add navigation to `ContentView` when selecting an option.
  - Implement `navigateToContentView` function as a placeholder for actual navigation logic.

* **WordWarsApp.swift**
  - Update the initial view to `OptionsPageView` instead of `StartPageView`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abbayram/coffemonkey/pull/18?shareId=7afe4d8e-1c5c-4fb2-a60a-997b63f4a8eb).